### PR TITLE
Use lazy-loaded pages with Suspense spinner

### DIFF
--- a/src/components/common/Spinner/index.tsx
+++ b/src/components/common/Spinner/index.tsx
@@ -1,0 +1,8 @@
+import {type ReactElement} from "react";
+import CircularProgress from "@mui/material/CircularProgress";
+
+const Spinner = (): ReactElement => {
+    return <CircularProgress/>;
+};
+
+export default Spinner;

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -1,19 +1,22 @@
 import routes from "./routes";
-import { type ReactElement } from "react";
-import { Route, Routes, type RouteObject } from "react-router";
+import Spinner from "@components/common/Spinner";
+import {Suspense, type ReactElement} from "react";
+import {Route, Routes, type RouteObject} from "react-router";
 
 const ApplicationRouter = (): ReactElement => {
     return (
-        <Routes>
-            {routes.map((route: RouteObject) => (
-                <Route
-                    id={route.id}
-                    key={route.id}
-                    path={route.path}
-                    element={route.element}
-                />
-            ))}
-        </Routes>
+        <Suspense fallback={<Spinner/>}>
+            <Routes>
+                {routes.map((route: RouteObject) => (
+                    <Route
+                        id={route.id}
+                        key={route.id}
+                        path={route.path}
+                        element={route.element}
+                    />
+                ))}
+            </Routes>
+        </Suspense>
     );
 };
 

--- a/src/router/routes.tsx
+++ b/src/router/routes.tsx
@@ -1,16 +1,18 @@
-import { type RouteObject } from "react-router";
-import HomePage from "@pages/Home";
-import NotFoundPage from "@pages/NotFound";
-import TrafficsLawsPage from "@pages/TrafficsLaws";
-import KazakhAdebiet from "@pages/KazakhAdebiet";
-import InProgress from "@pages/InProgress";
-import Chemistry from "@pages/Chemistry";
-import ComponentsPage from "@pages/Components";
-import RusLit from "@pages/RusLit";
-import Nutrition from "@pages/Nutrition";
-// import Mathematics from "@pages/Mathematics";
-// import SafetyPrecautions from "@pages/SafetyPrecautions";
-// import KazMusic from "@pages/KazMusic";
+import {lazy} from "react";
+import {type RouteObject} from "react-router";
+
+const HomePage = lazy(() => import("@pages/Home"));
+const NotFoundPage = lazy(() => import("@pages/NotFound"));
+const TrafficsLawsPage = lazy(() => import("@pages/TrafficsLaws"));
+const KazakhAdebiet = lazy(() => import("@pages/KazakhAdebiet"));
+const InProgress = lazy(() => import("@pages/InProgress"));
+const Chemistry = lazy(() => import("@pages/Chemistry"));
+const ComponentsPage = lazy(() => import("@pages/Components"));
+const RusLit = lazy(() => import("@pages/RusLit"));
+const Nutrition = lazy(() => import("@pages/Nutrition"));
+// const Mathematics = lazy(() => import("@pages/Mathematics"));
+// const SafetyPrecautions = lazy(() => import("@pages/SafetyPrecautions"));
+// const KazMusic = lazy(() => import("@pages/KazMusic"));
 
 export const paths = {
     HOME: {


### PR DESCRIPTION
## Summary
- lazy-load router pages for better bundle splitting
- wrap Routes with Suspense and Spinner fallback
- add reusable Spinner component using MUI CircularProgress

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any in src/pages/Components/stories/LargeCard/index.tsx)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b1ce2e5b7c8324b3237760292e3c57