### PR TITLE
feat: load assets from R2 storage

### DIFF
--- a/src/components/common/Cards/cardsMeta.tsx
+++ b/src/components/common/Cards/cardsMeta.tsx
@@ -1,7 +1,8 @@
 import type {IDefaultCardSxText, INestedCardSx} from "@components/common/Cards/CardsTypes.ts";
+import { R2_BASE_URL } from "@utils/constants";
 
-export const dsCardImagePathPrefixTemplate = './public/assets/ds-system/cards/';
-export const dsCardImagePathPrefix = './assets/images/';
+export const dsCardImagePathPrefixTemplate = `${R2_BASE_URL}assets/ds-system/cards/`;
+export const dsCardImagePathPrefix = `${R2_BASE_URL}assets/images/`;
 
 export const templateDSCardNames: string[] = [
     "ds-system/cards/ds-card-1.jpg",

--- a/src/components/common/Footers/StrictFooter/content.ts
+++ b/src/components/common/Footers/StrictFooter/content.ts
@@ -1,10 +1,12 @@
-import madeBySrcLight from "@assets/images/madeByLight.avif";
-import madeBySrcDark from "@assets/images/madeByDark.avif";
 import type {IDefaultDarkFooterMeta} from "@components/common/Footers/StrictFooter/types.ts";
+import { R2_BASE_URL } from "@utils/constants";
+
+const madeBySrcLight = `${R2_BASE_URL}assets/images/madeByLight.avif`;
+const madeBySrcDark = `${R2_BASE_URL}assets/images/madeByDark.avif`;
 
 export const trafficLawsFooterMeta: IDefaultDarkFooterMeta = {
     ru: {
-        logoPath: `./assets/images/sprite.svg#`,
+        logoPath: `${R2_BASE_URL}assets/images/sprite.svg#`,
         contacts: {
             email: "info@xraystand.kz",
             phone: "+7 (7172) 73-50-50",
@@ -28,7 +30,7 @@ export const trafficLawsFooterMeta: IDefaultDarkFooterMeta = {
         }
     },
     kz: {
-        logoPath: `./assets/images/sprite.svg#`,
+        logoPath: `${R2_BASE_URL}assets/images/sprite.svg#`,
         contacts: {
             email: "info@xraystand.kz",
             phone: "+7 (7172) 73-50-50",

--- a/src/components/common/Sections/TitleHeroSection/index.tsx
+++ b/src/components/common/Sections/TitleHeroSection/index.tsx
@@ -1,7 +1,7 @@
 import React, {type ReactElement} from "react";
 import type {IDefaultCardSxText} from "@components/common/Cards/CardsTypes.ts";
 import {defaultSectionSX} from "@components/common/Sections/meta.tsx";
-import heroBackground from "@assets/images/nutrition/backgrounds/hero.svg";
+import { R2_BASE_URL } from "@utils/constants";
 import "./style.css";
 
 export interface ITitleHeroSectionProps {
@@ -41,7 +41,10 @@ const TitleHeroSection: React.FC<ITitleHeroSectionProps> = ({
                     }}
                 >{subtitle}</p>
             </div>
-            <img src={heroBackground} alt="background"/>
+            <img
+                src={`${R2_BASE_URL}assets/images/nutrition/backgrounds/hero.svg`}
+                alt="background"
+            />
         </section>
     );
 };

--- a/src/modules/kazakhAdebietModule/Sections/CoverSection/index.tsx
+++ b/src/modules/kazakhAdebietModule/Sections/CoverSection/index.tsx
@@ -1,11 +1,14 @@
 import {type ReactElement} from "react";
-import coverImg from '@assets/images/kazakhAdebiet/cover.avif';
-import coverMobile from '@assets/images/kazakhAdebiet/coverMobile.avif';
+import { R2_BASE_URL } from "@utils/constants";
 import * as sectionContent from '@modules/kazakhAdebietModule/locales/kaz.json';
 import "./style.css";
 import useWindowWidth from "@hooks/useScreenWidth.ts";
 
-const CoverSection = (): ReactElement => {    const screenWidth = useWindowWidth();
+const coverImg = `${R2_BASE_URL}assets/images/kazakhAdebiet/cover.avif`;
+const coverMobile = `${R2_BASE_URL}assets/images/kazakhAdebiet/coverMobile.avif`;
+
+const CoverSection = (): ReactElement => {
+    const screenWidth = useWindowWidth();
 
     return (
         <section className="kza-cover-section">

--- a/src/modules/kazakhAdebietModule/Sections/SecondSection/index.tsx
+++ b/src/modules/kazakhAdebietModule/Sections/SecondSection/index.tsx
@@ -6,6 +6,7 @@ import DSCardsWrapper from "@components/common/Wrappers/DSCadsWrapper";
 import DSInformationCard from "@components/common/Cards/DSInformationCard";
 import * as content from "@modules/kazakhAdebietModule/locales/kaz.json";
 import "./style.css";
+import { R2_BASE_URL } from "@utils/constants";
 
 const rightColumnColorScheme: DSContentBlockColorScheme = {
     titleColor: "#EBCD91",
@@ -21,7 +22,10 @@ const SecondSection = (): ReactElement => {
         <section className="kza-second-section">
             <TwoColumnSection
                 leftColumn={
-                    <SquareImageViewer path={"assets/images/kazakhAdebiet/tree.avif"} width={564}/>
+                    <SquareImageViewer
+                        path={`${R2_BASE_URL}assets/images/kazakhAdebiet/tree.avif`}
+                        width={564}
+                    />
                 }
                 rightColumn={
                     <DSContentBlock

--- a/src/modules/rusLitModule/Sections/CoverSection/index.tsx
+++ b/src/modules/rusLitModule/Sections/CoverSection/index.tsx
@@ -1,7 +1,9 @@
 import {type ReactElement} from "react";
-import coverImg from '@assets/images/rusLit/backgrounds/coverBg.png';
+import { R2_BASE_URL } from "@utils/constants";
 import * as sectionContent from '@modules/rusLitModule/locales/rus.json';
 import "./style.css";
+
+const coverImg = `${R2_BASE_URL}assets/images/rusLit/backgrounds/coverBg.png`;
 
 const CoverSection = (): ReactElement => {
 

--- a/src/modules/rusLitModule/Sections/SecondSection/index.tsx
+++ b/src/modules/rusLitModule/Sections/SecondSection/index.tsx
@@ -3,6 +3,7 @@ import {type DSContentBlockColorScheme} from "@components/common/DSContentBlock"
 import BackgroundBlock from "@modules/rusLitModule/components/BackgroundBlock";
 import * as content from "@modules/rusLitModule/locales/rus.json";
 import * as paths from "@modules/rusLitModule/locales/paths.json";
+import { R2_BASE_URL } from "@utils/constants";
 import "./style.css";
 
 const rusLitTextColors: DSContentBlockColorScheme = {
@@ -12,7 +13,7 @@ const rusLitTextColors: DSContentBlockColorScheme = {
 }
 
 const SecondSection = (): ReactElement => {
-    const prefix = "./assets/images/";
+    const prefix = `${R2_BASE_URL}assets/images/`;
 
     return (
         <section className="ruslit-second-section">

--- a/src/modules/rusLitModule/Sections/ThirdSection/index.tsx
+++ b/src/modules/rusLitModule/Sections/ThirdSection/index.tsx
@@ -7,6 +7,7 @@ import DSInformationCard from "@components/common/Cards/DSInformationCard";
 
 import * as content from "@modules/rusLitModule/locales/rus.json";
 import * as paths from "@modules/rusLitModule/locales/paths.json";
+import { R2_BASE_URL } from "@utils/constants";
 import "./style.css";
 
 const notificationColorScheme = {
@@ -19,7 +20,7 @@ const notificationColorScheme = {
 }
 
 const SecondSection = (): ReactElement => {
-    const imagePrefix = "./assets/images/";
+    const imagePrefix = `${R2_BASE_URL}assets/images/`;
     const screenWidth = useScreenWidth();
 
     return (

--- a/src/modules/trafficLaws/Sections/CoverSection/index.tsx
+++ b/src/modules/trafficLaws/Sections/CoverSection/index.tsx
@@ -2,13 +2,15 @@ import { type ReactElement } from "react";
 import type {TRootState} from "@store/index.ts";
 import {Languages} from "@domains/Translate";
 import {useSelector} from "react-redux";
-import road from "../../../../../public/assets/images/trafficLawsPage/coverSection/road.avif";
-import carPng from "../../../../../public/assets/images/trafficLawsPage/coverSection/car.avif";
-import cloudsImg from "../../../../../public/assets/images/trafficLawsPage/coverSection/clouds.avif";
-import housesImg from "@assets/images/trafficLawsPage/coverSection/houses.avif";
+import { R2_BASE_URL } from "@utils/constants";
 import * as textContentKz from "@modules/trafficLaws/locales/kaz.json";
 import * as textContentRu from "@modules/trafficLaws/locales/rus.json";
 import "./style.css";
+
+const road = `${R2_BASE_URL}assets/images/trafficLawsPage/coverSection/road.avif`;
+const carPng = `${R2_BASE_URL}assets/images/trafficLawsPage/coverSection/car.avif`;
+const cloudsImg = `${R2_BASE_URL}assets/images/trafficLawsPage/coverSection/clouds.avif`;
+const housesImg = `${R2_BASE_URL}assets/images/trafficLawsPage/coverSection/houses.avif`;
 
 const CoverSection = (): ReactElement => {
     const currentLocale: Languages = useSelector(

--- a/src/modules/trafficLaws/Sections/FourthSection/index.tsx
+++ b/src/modules/trafficLaws/Sections/FourthSection/index.tsx
@@ -9,6 +9,7 @@ import {useSelector} from "react-redux";
 import type {TRootState} from "@store/index.ts";
 import * as textContentKz from "@modules/trafficLaws/locales/kaz.json";
 import * as textContentRu from "@modules/trafficLaws/locales/rus.json";
+import { R2_BASE_URL } from "@utils/constants";
 
 const FourthSection = (): ReactElement | null => {
     const currentLocale: Languages = useSelector(
@@ -30,7 +31,10 @@ const FourthSection = (): ReactElement | null => {
                 </LargeCard>
             }
             rightColumn={
-                <SquareImageViewer path={"/assets/images/trafficLawsPage/cyclistsScooters.avif"} width={564}/>
+                <SquareImageViewer
+                    path={`${R2_BASE_URL}assets/images/trafficLawsPage/cyclistsScooters.avif`}
+                    width={564}
+                />
             }
         />
     );

--- a/src/modules/trafficLaws/Sections/SeventhSection/index.tsx
+++ b/src/modules/trafficLaws/Sections/SeventhSection/index.tsx
@@ -10,6 +10,7 @@ import {useSelector} from "react-redux";
 import type {TRootState} from "@store/index.ts";
 import * as textContentKz from "@modules/trafficLaws/locales/kaz.json";
 import * as textContentRu from "@modules/trafficLaws/locales/rus.json";
+import { R2_BASE_URL } from "@utils/constants";
 
 const SeventhSection = (): ReactElement | null => {
     const currentLocale: Languages = useSelector(
@@ -23,7 +24,10 @@ const SeventhSection = (): ReactElement | null => {
     return (
         <TwoColumnSection
             leftColumn={
-                <SquareImageViewer path={"/assets/images/trafficLawsPage/pointsman.avif"} width={564}/>
+                <SquareImageViewer
+                    path={`${R2_BASE_URL}assets/images/trafficLawsPage/pointsman.avif`}
+                    width={564}
+                />
             }
             rightColumn={
                 <LargeCard

--- a/src/modules/trafficLaws/components/AnimatedTrafficLight/meta.ts
+++ b/src/modules/trafficLaws/components/AnimatedTrafficLight/meta.ts
@@ -11,33 +11,35 @@ export interface ITrafficLightsConfig {
     trafficLights: ITrafficLightConfig[];
 }
 
+import { R2_BASE_URL } from "@utils/constants";
+
 export const trafficLightsConfig: ITrafficLightsConfig = {
     backgroundImageSrc:
-        "./assets/images/trafficLawsPage/secondSection/tlBackground.avif",
+        `${R2_BASE_URL}assets/images/trafficLawsPage/secondSection/tlBackground.avif`,
     trafficLights: [
         {
             imageLightOnSrc:
-                "./assets/images/trafficLawsPage/secondSection/trafficLight/redOn.avif",
+                `${R2_BASE_URL}assets/images/trafficLawsPage/secondSection/trafficLight/redOn.avif`,
             imageLightOffSrc:
-                "./assets/images/trafficLawsPage/secondSection/trafficLight/redOff.avif",
+                `${R2_BASE_URL}assets/images/trafficLawsPage/secondSection/trafficLight/redOff.avif`,
             color: "red",
             activeLabelRu: "Красный — стой",
             activeLabelkz: "Қызыл — тоқта.",
         },
         {
             imageLightOnSrc:
-                "./assets/images/trafficLawsPage/secondSection/trafficLight/yellowOn.avif",
+                `${R2_BASE_URL}assets/images/trafficLawsPage/secondSection/trafficLight/yellowOn.avif`,
             imageLightOffSrc:
-                "./assets/images/trafficLawsPage/secondSection/trafficLight/yellowOff.avif",
+                `${R2_BASE_URL}assets/images/trafficLawsPage/secondSection/trafficLight/yellowOff.avif`,
             color: "yellow",
             activeLabelRu: "Жёлтый — приготовься",
             activeLabelkz: "Сары — дайындал.",
         },
         {
             imageLightOnSrc:
-                "./assets/images/trafficLawsPage/secondSection/trafficLight/greenOn.avif",
+                `${R2_BASE_URL}assets/images/trafficLawsPage/secondSection/trafficLight/greenOn.avif`,
             imageLightOffSrc:
-                "./assets/images/trafficLawsPage/secondSection/trafficLight/greenOff.avif",
+                `${R2_BASE_URL}assets/images/trafficLawsPage/secondSection/trafficLight/greenOff.avif`,
             color: "green",
             activeLabelRu: "Зелёный — можно идти",
             activeLabelkz: "Жасыл — өтуге болады.",

--- a/src/pages/Components/stories/footer/index.tsx
+++ b/src/pages/Components/stories/footer/index.tsx
@@ -1,8 +1,10 @@
 import { useState } from "react";
 import type { IStrictFooterContent } from "@components/common/Footers/StrictFooter/types";
 import Footer from "@components/common/Footers/StrictFooter";
-import madeBySrcLight from "@assets/images/madeByLight.avif";
-import madeBySrcDark from "@assets/images/madeByDark.avif";
+import { R2_BASE_URL } from "@utils/constants";
+
+const madeBySrcLight = `${R2_BASE_URL}assets/images/madeByLight.avif`;
+const madeBySrcDark = `${R2_BASE_URL}assets/images/madeByDark.avif`;
 
 export const defaultFooterSX = {
     backgroundColor: "#181818",
@@ -14,7 +16,7 @@ export const defaultFooterSX = {
 };
 
 export const strictFooterMeta: IStrictFooterContent = {
-    logoPath: `./assets/images/sprite.svg#`,
+    logoPath: `${R2_BASE_URL}assets/images/sprite.svg#`,
     contacts: {
         email: "hello@example.com",
         phone: "+7 (999) 123-45-67",

--- a/src/pages/InProgress/index.tsx
+++ b/src/pages/InProgress/index.tsx
@@ -3,6 +3,7 @@ import DefaultLayout from "@layout/Default";
 import ContentSection from "@components/common/Sections/DSContentSection";
 import useWindowWidth from "@hooks/useScreenWidth.ts";
 import DSNotification from "@components/common/DSNotification";
+import { R2_BASE_URL } from "@utils/constants";
 import "./style.css";
 
 const textContent = {
@@ -23,9 +24,9 @@ const InProgress = (): ReactElement => {
                 <div className="in-progress-container">
                     <svg className="animated-svg">
                         <use
-                            href={`./assets/images/sprite.svg#${
-                                screenWidth > 800 ? 
-                                    "inProgressDesktop" : 
+                            href={`${R2_BASE_URL}assets/images/sprite.svg#${
+                                screenWidth > 800 ?
+                                    "inProgressDesktop" :
                                     "inProgressMobile"
                             }`}/>
                     </svg>

--- a/src/utils/constants/index.ts
+++ b/src/utils/constants/index.ts
@@ -14,12 +14,15 @@ export const enum LocalStorageKeys {
     LOCALE = "locale",
 }
 
-export const svgSpriteSrcPrefix: string = "./assets/images/sprite.svg#";
-export const contentImageSrcPrefix: string = "./assets/images/";
-export const contentAnimationsSrcPrefix: string = "./assets/images/animations/";
+export const R2_BASE_URL =
+    "https://e1901c8caf5e6cdb708c4ae2a3d0f235.r2.cloudflarestorage.com/xraystand/";
+
+export const svgSpriteSrcPrefix: string = `${R2_BASE_URL}assets/images/sprite.svg#`;
+export const contentImageSrcPrefix: string = `${R2_BASE_URL}assets/images/`;
+export const contentAnimationsSrcPrefix: string = `${R2_BASE_URL}assets/images/animations/`;
 export const contentImageSrcSuffix: string = ".avif";
 
-export const contentDSCardsSrcPrefix: string = "./public/assets/images/ds-system/cards/";
+export const contentDSCardsSrcPrefix: string = `${R2_BASE_URL}assets/images/ds-system/cards/`;
 
 export const enum SvgSpriteIds {
     LOGO = "logo",


### PR DESCRIPTION
## Summary
- add R2_BASE_URL constant and update asset path prefixes
- build image and sprite URLs dynamically using the R2 base URL
- remove static image imports across modules and footer content

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any in src/pages/Components/stories/LargeCard/index.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b2f694cdf883249a5d393ebf12f86d