### PR TITLE
feat: add image preloader hook

### DIFF
--- a/src/domains/Translate/index.ts
+++ b/src/domains/Translate/index.ts
@@ -59,6 +59,14 @@ export const enum PageIds {
     CHEMISTRY_PAGE = "chemistryPage",
     RUSLIT_PAGE = "ruslitPage",
     KAZAKH_ADEBIET_PAGE = "kazakhadebietPage",
+    HOME_PAGE = "homePage",
+    SAFETY_PRECAUTIONS_PAGE = "safetyPrecautionsPage",
+    MATHEMATICS_PAGE = "mathematicsPage",
+    SPINNER_DEMO_PAGE = "spinnerDemoPage",
+    COMPONENTS_PAGE = "componentsPage",
+    IN_PROGRESS_PAGE = "inProgressPage",
+    NUTRITION_PAGE = "nutritionPage",
+    NOT_FOUND_PAGE = "notFoundPage",
 };
 
 export const enum PageSectionIds {

--- a/src/hooks/useImagesPreloader.ts
+++ b/src/hooks/useImagesPreloader.ts
@@ -1,0 +1,44 @@
+import { useEffect, useState } from "react";
+import getImageUrl from "@utils/getImageUrl";
+
+const useImagesPreloader = (imageIds: string[]) => {
+    const [isLoaded, setIsLoaded] = useState(false);
+
+    useEffect(() => {
+        const uniqueIds = Array.from(new Set(imageIds));
+        if (uniqueIds.length === 0) {
+            setIsLoaded(true);
+            return;
+        }
+
+        let loadedCount = 0;
+        let isCancelled = false;
+
+        const handleComplete = () => {
+            loadedCount += 1;
+            if (loadedCount === uniqueIds.length && !isCancelled) {
+                setIsLoaded(true);
+            }
+        };
+
+        const images = uniqueIds.map((id) => {
+            const img = new Image();
+            img.onload = handleComplete;
+            img.onerror = handleComplete;
+            img.src = getImageUrl(id);
+            return img;
+        });
+
+        return () => {
+            isCancelled = true;
+            images.forEach((img) => {
+                img.onload = null;
+                img.onerror = null;
+            });
+        };
+    }, [imageIds]);
+
+    return { isLoaded };
+};
+
+export default useImagesPreloader;

--- a/src/pages/Chemistry/index.tsx
+++ b/src/pages/Chemistry/index.tsx
@@ -1,4 +1,8 @@
-import {type ReactElement} from "react";
+import {type ReactElement, useMemo} from "react";
+import Spinner from "@components/common/Spinner";
+import useImagesPreloader from "@hooks/useImagesPreloader";
+import usePageImagesIds from "@hooks/usePageImagesIds";
+import { PageIds } from "@domains/Translate";
 import {useDispatch, useSelector} from "react-redux";
 import type {IContentSectionProps, ITextContent} from "@pages/Chemistry/types.ts";
 import {Languages} from "@domains/Translate";
@@ -22,6 +26,24 @@ const Chemistry = (): ReactElement => {
     const currentLocale: Languages = useSelector(
         (state: TRootState) => state.locale.locale
     );
+
+    const { pageImageIdData } = usePageImagesIds(PageIds.CHEMISTRY_PAGE);
+    const imageIds = useMemo(() => {
+        if (!pageImageIdData) return [];
+        return Array.from(
+            new Set(
+                Object.values(pageImageIdData).flatMap(section => [
+                    ...section.globalData,
+                    ...section.contentListData,
+                ]),
+            ),
+        );
+    }, [pageImageIdData]);
+    const { isLoaded } = useImagesPreloader(imageIds);
+
+    if (!isLoaded) {
+        return <Spinner />;
+    }
 
     const sectionMeta = currentLocale === "kz" ? contentKZ : contentRU;
     const sectionMetaTranslation: ITextContent = sectionMeta.section;

--- a/src/pages/Components/index.tsx
+++ b/src/pages/Components/index.tsx
@@ -1,4 +1,8 @@
-import { type FC, type ReactElement, type ReactNode, useState } from "react";
+import { type FC, type ReactElement, type ReactNode, useState, useMemo} from "react";
+import Spinner from "@components/common/Spinner";
+import useImagesPreloader from "@hooks/useImagesPreloader";
+import usePageImagesIds from "@hooks/usePageImagesIds";
+import { PageIds } from "@domains/Translate";
 import { MDXProvider } from "@mdx-js/react";
 import { componentsLibrary } from "@pages/Components/meta.tsx";
 import { mdxComponents } from "@utils/mdxComponents.tsx";
@@ -35,6 +39,24 @@ const ComponentsPage = (): ReactElement => {
     const [currentComponent, setCurrentComponent] = useState<IComponentData>(
         componentsLibrary[0]
     );
+
+    const { pageImageIdData } = usePageImagesIds(PageIds.COMPONENTS_PAGE);
+    const imageIds = useMemo(() => {
+        if (!pageImageIdData) return [];
+        return Array.from(
+            new Set(
+                Object.values(pageImageIdData).flatMap(section => [
+                    ...section.globalData,
+                    ...section.contentListData,
+                ]),
+            ),
+        );
+    }, [pageImageIdData]);
+    const { isLoaded } = useImagesPreloader(imageIds);
+
+    if (!isLoaded) {
+        return <Spinner />;
+    }
 
     const handleClick = (index: number): void => {
         setCurrentComponent(componentsLibrary[index]);

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -1,8 +1,29 @@
-import { type ReactElement } from "react";
+import {type ReactElement, useMemo} from "react";
+import Spinner from "@components/common/Spinner";
+import useImagesPreloader from "@hooks/useImagesPreloader";
+import usePageImagesIds from "@hooks/usePageImagesIds";
+import { PageIds } from "@domains/Translate";
 import {Link} from "react-router";
 import './style.css';
 
 const HomePage = (): ReactElement => {
+    const { pageImageIdData } = usePageImagesIds(PageIds.HOME_PAGE);
+    const imageIds = useMemo(() => {
+        if (!pageImageIdData) return [];
+        return Array.from(
+            new Set(
+                Object.values(pageImageIdData).flatMap(section => [
+                    ...section.globalData,
+                    ...section.contentListData,
+                ]),
+            ),
+        );
+    }, [pageImageIdData]);
+    const { isLoaded } = useImagesPreloader(imageIds);
+
+    if (!isLoaded) {
+        return <Spinner />;
+    }
 
     return(
         <div className="home-page">

--- a/src/pages/InProgress/index.tsx
+++ b/src/pages/InProgress/index.tsx
@@ -1,4 +1,8 @@
-import {type ReactElement} from "react";
+import {type ReactElement, useMemo} from "react";
+import Spinner from "@components/common/Spinner";
+import useImagesPreloader from "@hooks/useImagesPreloader";
+import usePageImagesIds from "@hooks/usePageImagesIds";
+import { PageIds } from "@domains/Translate";
 import DefaultLayout from "@layout/Default";
 import ContentSection from "@components/common/Sections/DSContentSection";
 import useWindowWidth from "@hooks/useScreenWidth.ts";
@@ -16,6 +20,24 @@ const textContent = {
 
 const InProgress = (): ReactElement => {
     const screenWidth = useWindowWidth();
+
+    const { pageImageIdData } = usePageImagesIds(PageIds.IN_PROGRESS_PAGE);
+    const imageIds = useMemo(() => {
+        if (!pageImageIdData) return [];
+        return Array.from(
+            new Set(
+                Object.values(pageImageIdData).flatMap(section => [
+                    ...section.globalData,
+                    ...section.contentListData,
+                ]),
+            ),
+        );
+    }, [pageImageIdData]);
+    const { isLoaded } = useImagesPreloader(imageIds);
+
+    if (!isLoaded) {
+        return <Spinner />;
+    }
 
     return (
         <DefaultLayout disabled={true}>

--- a/src/pages/KazakhAdebiet/index.tsx
+++ b/src/pages/KazakhAdebiet/index.tsx
@@ -1,4 +1,8 @@
-import {type ReactElement} from "react";
+import {type ReactElement, useMemo} from "react";
+import Spinner from "@components/common/Spinner";
+import useImagesPreloader from "@hooks/useImagesPreloader";
+import usePageImagesIds from "@hooks/usePageImagesIds";
+import { PageIds } from "@domains/Translate";
 import DefaultLayout from "@layout/Default";
 import CoverSection from "@modules/kazakhAdebietModule/Sections/CoverSection";
 import FirstSection from "@modules/kazakhAdebietModule/Sections/FirstSection";
@@ -7,6 +11,23 @@ import ThirdSection from "@modules/kazakhAdebietModule/Sections/ThirdSection";
 import "./style.css";
 
 const KazakhAdebiet = (): ReactElement => {
+    const { pageImageIdData } = usePageImagesIds(PageIds.KAZAKH_ADEBIET_PAGE);
+    const imageIds = useMemo(() => {
+        if (!pageImageIdData) return [];
+        return Array.from(
+            new Set(
+                Object.values(pageImageIdData).flatMap(section => [
+                    ...section.globalData,
+                    ...section.contentListData,
+                ]),
+            ),
+        );
+    }, [pageImageIdData]);
+    const { isLoaded } = useImagesPreloader(imageIds);
+
+    if (!isLoaded) {
+        return <Spinner />;
+    }
     return (
         <DefaultLayout strictLanguage='kz'>
             <div className="kazakh-adebiet-page">

--- a/src/pages/Mathematics/index.tsx
+++ b/src/pages/Mathematics/index.tsx
@@ -1,7 +1,28 @@
-import {type ReactElement} from "react";
+import {type ReactElement, useMemo} from "react";
+import Spinner from "@components/common/Spinner";
+import useImagesPreloader from "@hooks/useImagesPreloader";
+import usePageImagesIds from "@hooks/usePageImagesIds";
+import { PageIds } from "@domains/Translate";
 import "./style.css";
 
 const Mathematics = (): ReactElement => {
+    const { pageImageIdData } = usePageImagesIds(PageIds.MATHEMATICS_PAGE);
+    const imageIds = useMemo(() => {
+        if (!pageImageIdData) return [];
+        return Array.from(
+            new Set(
+                Object.values(pageImageIdData).flatMap(section => [
+                    ...section.globalData,
+                    ...section.contentListData,
+                ]),
+            ),
+        );
+    }, [pageImageIdData]);
+    const { isLoaded } = useImagesPreloader(imageIds);
+
+    if (!isLoaded) {
+        return <Spinner />;
+    }
     return (
         <></>
     );

--- a/src/pages/NotFound/index.tsx
+++ b/src/pages/NotFound/index.tsx
@@ -1,6 +1,27 @@
-import { type ReactElement } from "react";
+import {type ReactElement, useMemo} from "react";
+import Spinner from "@components/common/Spinner";
+import useImagesPreloader from "@hooks/useImagesPreloader";
+import usePageImagesIds from "@hooks/usePageImagesIds";
+import { PageIds } from "@domains/Translate";
 
 const NotFoundPage = (): ReactElement => {
+    const { pageImageIdData } = usePageImagesIds(PageIds.NOT_FOUND_PAGE);
+    const imageIds = useMemo(() => {
+        if (!pageImageIdData) return [];
+        return Array.from(
+            new Set(
+                Object.values(pageImageIdData).flatMap(section => [
+                    ...section.globalData,
+                    ...section.contentListData,
+                ]),
+            ),
+        );
+    }, [pageImageIdData]);
+    const { isLoaded } = useImagesPreloader(imageIds);
+
+    if (!isLoaded) {
+        return <Spinner />;
+    }
     return <div className="not-found-page">Not Found Page</div>;
 };
 

--- a/src/pages/Nutrition/index.tsx
+++ b/src/pages/Nutrition/index.tsx
@@ -1,4 +1,8 @@
-import React, {type ReactElement} from "react";
+import React, {type ReactElement, useMemo} from "react";
+import Spinner from "@components/common/Spinner";
+import useImagesPreloader from "@hooks/useImagesPreloader";
+import usePageImagesIds from "@hooks/usePageImagesIds";
+import { PageIds } from "@domains/Translate";
 import type {TRootState} from "@store/index.ts";
 import type {NutritionLocale} from "@modules/nutrition/types";
 import {useSelector} from "react-redux";
@@ -33,6 +37,24 @@ const Nutrition: React.FC = (): ReactElement => {
         (state: TRootState) => state.locale.locale
     );
     const content: NutritionLocale = currentLocale === 'ru' ? contentRu : contentKz;
+
+    const { pageImageIdData } = usePageImagesIds(PageIds.NUTRITION_PAGE);
+    const imageIds = useMemo(() => {
+        if (!pageImageIdData) return [];
+        return Array.from(
+            new Set(
+                Object.values(pageImageIdData).flatMap(section => [
+                    ...section.globalData,
+                    ...section.contentListData,
+                ]),
+            ),
+        );
+    }, [pageImageIdData]);
+    const { isLoaded } = useImagesPreloader(imageIds);
+
+    if (!isLoaded) {
+        return <Spinner />;
+    }
 
     const scrollTo = (id: string) => {
         const el = document.getElementById(id);

--- a/src/pages/RusLit/index.tsx
+++ b/src/pages/RusLit/index.tsx
@@ -1,4 +1,8 @@
-import {type ReactElement} from "react";
+import {type ReactElement, useMemo} from "react";
+import Spinner from "@components/common/Spinner";
+import useImagesPreloader from "@hooks/useImagesPreloader";
+import usePageImagesIds from "@hooks/usePageImagesIds";
+import { PageIds } from "@domains/Translate";
 import DefaultLayout from "@layout/Default";
 import CoverSection from "@modules/rusLitModule/Sections/CoverSection";
 import FirstSection from "@modules/rusLitModule/Sections/FirstSection";
@@ -7,6 +11,23 @@ import ThirdSection from "@modules/rusLitModule/Sections/ThirdSection";
 import "./style.css";
 
 const RusLit = (): ReactElement => {
+    const { pageImageIdData } = usePageImagesIds(PageIds.RUSLIT_PAGE);
+    const imageIds = useMemo(() => {
+        if (!pageImageIdData) return [];
+        return Array.from(
+            new Set(
+                Object.values(pageImageIdData).flatMap(section => [
+                    ...section.globalData,
+                    ...section.contentListData,
+                ]),
+            ),
+        );
+    }, [pageImageIdData]);
+    const { isLoaded } = useImagesPreloader(imageIds);
+
+    if (!isLoaded) {
+        return <Spinner />;
+    }
     return (
         <DefaultLayout strictLanguage='ru'>
             <div className="ruslit-page" >

--- a/src/pages/SafetyPrecautions/index.tsx
+++ b/src/pages/SafetyPrecautions/index.tsx
@@ -1,7 +1,28 @@
-import {type ReactElement} from "react";
+import {type ReactElement, useMemo} from "react";
+import Spinner from "@components/common/Spinner";
+import useImagesPreloader from "@hooks/useImagesPreloader";
+import usePageImagesIds from "@hooks/usePageImagesIds";
+import { PageIds } from "@domains/Translate";
 import "./style.css";
 
 const SafetyPrecautions = (): ReactElement => {
+    const { pageImageIdData } = usePageImagesIds(PageIds.SAFETY_PRECAUTIONS_PAGE);
+    const imageIds = useMemo(() => {
+        if (!pageImageIdData) return [];
+        return Array.from(
+            new Set(
+                Object.values(pageImageIdData).flatMap(section => [
+                    ...section.globalData,
+                    ...section.contentListData,
+                ]),
+            ),
+        );
+    }, [pageImageIdData]);
+    const { isLoaded } = useImagesPreloader(imageIds);
+
+    if (!isLoaded) {
+        return <Spinner />;
+    }
     return (
         <></>
     );

--- a/src/pages/SpinnerDemo/index.tsx
+++ b/src/pages/SpinnerDemo/index.tsx
@@ -1,4 +1,8 @@
-import React, {type ReactElement} from "react";
+import React, {type ReactElement, useMemo} from "react";
+import Spinner from "@components/common/Spinner";
+import useImagesPreloader from "@hooks/useImagesPreloader";
+import usePageImagesIds from "@hooks/usePageImagesIds";
+import { PageIds } from "@domains/Translate";
 import type {NutritionLocale} from "@modules/nutrition/types";
 import useScreenWidth from "@hooks/useScreenWidth.ts";
 import BrightnessLayout from "@layout/Brightness";
@@ -6,7 +10,6 @@ import NutritionLogo from "@modules/nutrition/components/NutritionLogo";
 import NutritionNav from "@modules/nutrition/components/NutritionNav";
 import FirstSection from "@modules/nutrition/Sections/FirstSection";
 import TitleHeroSection from "@components/common/Sections/TitleHeroSection";
-import Spinner from "@components/common/Spinner";
 import * as contentRu from "@modules/nutrition/locales/rus.json";
 import "./style.css";
 
@@ -24,6 +27,24 @@ const SpinnerDemo: React.FC = (): ReactElement => {
     const screenWidth = useScreenWidth();
     const content: NutritionLocale = contentRu;
 
+    const { pageImageIdData } = usePageImagesIds(PageIds.SPINNER_DEMO_PAGE);
+    const imageIds = useMemo(() => {
+        if (!pageImageIdData) return [];
+        return Array.from(
+            new Set(
+                Object.values(pageImageIdData).flatMap(section => [
+                    ...section.globalData,
+                    ...section.contentListData,
+                ]),
+            ),
+        );
+    }, [pageImageIdData]);
+    const { isLoaded } = useImagesPreloader(imageIds);
+
+    if (!isLoaded) {
+        return <Spinner />;
+    }
+
 
     return (
         <BrightnessLayout
@@ -31,7 +52,6 @@ const SpinnerDemo: React.FC = (): ReactElement => {
             navigation={<NutritionNav />}
             stickyHeader={true}
         >
-            <Spinner />
             <section id={SECTION_IDS.cover} className="nutrition-section">
                 <TitleHeroSection
                     title={content.coverSection.title}

--- a/src/pages/TrafficsLaws/index.tsx
+++ b/src/pages/TrafficsLaws/index.tsx
@@ -1,4 +1,8 @@
-import {type ReactElement} from "react";
+import {type ReactElement, useMemo} from "react";
+import Spinner from "@components/common/Spinner";
+import useImagesPreloader from "@hooks/useImagesPreloader";
+import usePageImagesIds from "@hooks/usePageImagesIds";
+import { PageIds } from "@domains/Translate";
 import type {TRootState} from "@store/index.ts";
 import type {IContentLabel, TContentItem} from "@utils/types/trafficLawsTypes";
 import {useDispatch, useSelector} from "react-redux";
@@ -108,11 +112,28 @@ const signsImagesPaths: Record<string, string[]> = {
 
 const TrafficsLawsPage = (): ReactElement => {
     const dispatch = useDispatch();
-
     const isModalOpened: boolean = useSelector((state: TRootState) => state.application.isModalOpened);
     const modalContentName: TContentItem =
         useSelector((state: TRootState) => state.trafficLaws.modalContentName) as IContentLabel;
     const title = modalContentName?.title || "";
+
+    const { pageImageIdData } = usePageImagesIds(PageIds.TRAFFIC_LAWS_PAGE);
+    const imageIds = useMemo(() => {
+        if (!pageImageIdData) return [];
+        return Array.from(
+            new Set(
+                Object.values(pageImageIdData).flatMap(section => [
+                    ...section.globalData,
+                    ...section.contentListData,
+                ]),
+            ),
+        );
+    }, [pageImageIdData]);
+    const { isLoaded } = useImagesPreloader(imageIds);
+
+    if (!isLoaded) {
+        return <Spinner />;
+    }
 
     const splitString = (str: string): string[] => {
         const i = str.indexOf("—");

--- a/src/utils/getImageUrl.ts
+++ b/src/utils/getImageUrl.ts
@@ -1,0 +1,5 @@
+import { contentImageSrcPrefix, contentImageSrcSuffix } from "@utils/constants";
+
+const getImageUrl = (imageId: string): string => `${contentImageSrcPrefix}${imageId}${contentImageSrcSuffix}`;
+
+export default getImageUrl;


### PR DESCRIPTION
## Summary
- preload page images with new `useImagesPreloader`
- gather image ids for each page and show spinner until loaded

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 5 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b3268620d083248e4b8f8e11a784f1