### PR TITLE
Use Cloudinary IDs for traffic light assets

### DIFF
--- a/src/data/cloudinary.ts
+++ b/src/data/cloudinary.ts
@@ -1,0 +1,13 @@
+const cloudinaryUrlsRecord: Record<string, string> = {
+  "trafficLawsPage/trafficLight/background": "https://res.cloudinary.com/dy6zg8dhs/image/upload/v1756567690/tlBackground_co473s.avif",
+  "trafficLawsPage/trafficLight/redOn": "https://res.cloudinary.com/dy6zg8dhs/image/upload/v1756567691/redOn_nizxqb.avif",
+  "trafficLawsPage/trafficLight/redOff": "https://res.cloudinary.com/dy6zg8dhs/image/upload/v1756567690/redOff_tsib2i.avif",
+  "trafficLawsPage/trafficLight/yellowOn": "https://res.cloudinary.com/dy6zg8dhs/image/upload/v1756567691/yellowOn_lcofvk.avif",
+  "trafficLawsPage/trafficLight/yellowOff": "https://res.cloudinary.com/dy6zg8dhs/image/upload/v1756567690/yellowOff_al1oni.avif",
+  "trafficLawsPage/trafficLight/greenOn": "https://res.cloudinary.com/dy6zg8dhs/image/upload/v1756567690/greenOn_kacswf.avif",
+  "trafficLawsPage/trafficLight/greenOff": "https://res.cloudinary.com/dy6zg8dhs/image/upload/v1756567689/greenOff_rwoxvf.avif",
+};
+
+export const getImageUrl = (id: string): string => cloudinaryUrlsRecord[id];
+
+export default cloudinaryUrlsRecord;

--- a/src/data/imageSrc.json
+++ b/src/data/imageSrc.json
@@ -12,7 +12,13 @@
         "secondSection": {
             "contentListData": [],
             "globalData": [
-                "trafficLawsPage/trafficLight"
+                "trafficLawsPage/trafficLight/background",
+                "trafficLawsPage/trafficLight/redOn",
+                "trafficLawsPage/trafficLight/redOff",
+                "trafficLawsPage/trafficLight/yellowOn",
+                "trafficLawsPage/trafficLight/yellowOff",
+                "trafficLawsPage/trafficLight/greenOn",
+                "trafficLawsPage/trafficLight/greenOff"
             ]
         },
         "thirdSection": {

--- a/src/modules/trafficLaws/components/AnimatedTrafficLight/meta.ts
+++ b/src/modules/trafficLaws/components/AnimatedTrafficLight/meta.ts
@@ -11,33 +11,28 @@ export interface ITrafficLightsConfig {
     trafficLights: ITrafficLightConfig[];
 }
 
+import { getImageUrl } from "@data/cloudinary";
+
 export const trafficLightsConfig: ITrafficLightsConfig = {
-    backgroundImageSrc:
-        "./assets/images/trafficLawsPage/secondSection/tlBackground.avif",
+    backgroundImageSrc: getImageUrl("trafficLawsPage/trafficLight/background"),
     trafficLights: [
         {
-            imageLightOnSrc:
-                "./assets/images/trafficLawsPage/secondSection/trafficLight/redOn.avif",
-            imageLightOffSrc:
-                "./assets/images/trafficLawsPage/secondSection/trafficLight/redOff.avif",
+            imageLightOnSrc: getImageUrl("trafficLawsPage/trafficLight/redOn"),
+            imageLightOffSrc: getImageUrl("trafficLawsPage/trafficLight/redOff"),
             color: "red",
             activeLabelRu: "Красный — стой",
             activeLabelkz: "Қызыл — тоқта.",
         },
         {
-            imageLightOnSrc:
-                "./assets/images/trafficLawsPage/secondSection/trafficLight/yellowOn.avif",
-            imageLightOffSrc:
-                "./assets/images/trafficLawsPage/secondSection/trafficLight/yellowOff.avif",
+            imageLightOnSrc: getImageUrl("trafficLawsPage/trafficLight/yellowOn"),
+            imageLightOffSrc: getImageUrl("trafficLawsPage/trafficLight/yellowOff"),
             color: "yellow",
             activeLabelRu: "Жёлтый — приготовься",
             activeLabelkz: "Сары — дайындал.",
         },
         {
-            imageLightOnSrc:
-                "./assets/images/trafficLawsPage/secondSection/trafficLight/greenOn.avif",
-            imageLightOffSrc:
-                "./assets/images/trafficLawsPage/secondSection/trafficLight/greenOff.avif",
+            imageLightOnSrc: getImageUrl("trafficLawsPage/trafficLight/greenOn"),
+            imageLightOffSrc: getImageUrl("trafficLawsPage/trafficLight/greenOff"),
             color: "green",
             activeLabelRu: "Зелёный — можно идти",
             activeLabelkz: "Жасыл — өтуге болады.",


### PR DESCRIPTION
## Summary
- assign unique IDs to traffic light images and add Cloudinary URLs
- load traffic light images via `getImageUrl` rather than local assets
- list all traffic light image IDs for preloading

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: existing lint errors)
- `npx eslint src/modules/trafficLaws/components/AnimatedTrafficLight/meta.ts src/data/cloudinary.ts src/data/imageSrc.json`

------
https://chatgpt.com/codex/tasks/task_e_68b3269a25d0832495f9419bf0fe891e