### PR TITLE
refactor: use getImageUrl for Kazakh Adebiet assets

### DIFF
--- a/src/data/imageSrc.json
+++ b/src/data/imageSrc.json
@@ -77,5 +77,24 @@
             ],
             "globalData": []
         }
+    },
+    "kazakhadebietPage": {
+        "firstSection": {
+            "contentListData": [],
+            "globalData": [
+                "kazakhAdebeit/cover",
+                "kazakhAdebeit/coverMobile"
+            ]
+        },
+        "secondSection": {
+            "contentListData": [],
+            "globalData": [
+                "kazakhAdebeit/tree"
+            ]
+        },
+        "thirdSection": {
+            "contentListData": [],
+            "globalData": []
+        }
     }
 }

--- a/src/modules/kazakhAdebietModule/Sections/CoverSection/index.tsx
+++ b/src/modules/kazakhAdebietModule/Sections/CoverSection/index.tsx
@@ -1,16 +1,20 @@
 import {type ReactElement} from "react";
-import coverImg from '@assets/images/kazakhAdebiet/cover.avif';
-import coverMobile from '@assets/images/kazakhAdebiet/coverMobile.avif';
+import getImageUrl from "@utils/getImageUrl.ts";
 import * as sectionContent from '@modules/kazakhAdebietModule/locales/kaz.json';
 import "./style.css";
 import useWindowWidth from "@hooks/useScreenWidth.ts";
 
-const CoverSection = (): ReactElement => {    const screenWidth = useWindowWidth();
+const CoverSection = (): ReactElement => {
+    const screenWidth = useWindowWidth();
 
     return (
         <section className="kza-cover-section">
-            {screenWidth > 870 && <img src={coverImg} alt=''/>}
-            {screenWidth < 870 && <img src={coverMobile} alt=''/>}
+            {screenWidth > 870 && (
+                <img src={getImageUrl('kazakhAdebeit/cover')} alt="" />
+            )}
+            {screenWidth < 870 && (
+                <img src={getImageUrl('kazakhAdebeit/coverMobile')} alt="" />
+            )}
 
             <div className="kza-cover-text-content">
                 <h1>{sectionContent.coverSection.title}</h1>

--- a/src/modules/kazakhAdebietModule/Sections/SecondSection/index.tsx
+++ b/src/modules/kazakhAdebietModule/Sections/SecondSection/index.tsx
@@ -6,6 +6,7 @@ import DSCardsWrapper from "@components/common/Wrappers/DSCadsWrapper";
 import DSInformationCard from "@components/common/Cards/DSInformationCard";
 import * as content from "@modules/kazakhAdebietModule/locales/kaz.json";
 import "./style.css";
+import getImageUrl from "@utils/getImageUrl.ts";
 
 const rightColumnColorScheme: DSContentBlockColorScheme = {
     titleColor: "#EBCD91",
@@ -21,7 +22,7 @@ const SecondSection = (): ReactElement => {
         <section className="kza-second-section">
             <TwoColumnSection
                 leftColumn={
-                    <SquareImageViewer path={"assets/images/kazakhAdebiet/tree.avif"} width={564}/>
+                    <SquareImageViewer path={getImageUrl('kazakhAdebeit/tree')} width={564}/>
                 }
                 rightColumn={
                     <DSContentBlock

--- a/src/utils/getImageUrl.ts
+++ b/src/utils/getImageUrl.ts
@@ -1,0 +1,7 @@
+import { contentImageSrcPrefix, contentImageSrcSuffix } from "@utils/constants";
+
+const getImageUrl = (id: string): string => {
+    return `${contentImageSrcPrefix}${id}${contentImageSrcSuffix}`;
+};
+
+export default getImageUrl;


### PR DESCRIPTION
## Summary
- add helper to build image asset URLs
- use getImageUrl for Kazakh Adebiet cover and tree images
- register Kazakh Adebiet image IDs for preloading

## Testing
- `npm run lint` *(fails: Unexpected any in existing story files)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b326a0dc208324b8a43b5f3ee9675a