### PR TITLE
refactor: use cloudinary for ruslit cover

### DIFF
--- a/src/modules/rusLitModule/Sections/CoverSection/index.tsx
+++ b/src/modules/rusLitModule/Sections/CoverSection/index.tsx
@@ -1,6 +1,7 @@
 import {type ReactElement} from "react";
-import coverImg from '@assets/images/rusLit/backgrounds/coverBg.png';
+import * as paths from "@modules/rusLitModule/locales/paths.json";
 import * as sectionContent from '@modules/rusLitModule/locales/rus.json';
+import getImageUrl from "@utils/cloudinary";
 import "./style.css";
 
 const CoverSection = (): ReactElement => {
@@ -8,7 +9,7 @@ const CoverSection = (): ReactElement => {
     return (
         <section className="ruslit-cover-section">
             <div className="ruslit-cover-section-image-container">
-                <img src={coverImg} alt='cover'/>
+                <img src={getImageUrl(paths.backgrounds.cover)} alt='cover'/>
             </div>
 
             <div className="ruslit-cover-text-content">

--- a/src/utils/cloudinary.ts
+++ b/src/utils/cloudinary.ts
@@ -1,0 +1,9 @@
+export const cloudinaryUrls: Record<string, string> = {
+    "rusLit/backgrounds/coverBg.avif": "https://res.cloudinary.com/dy6zg8dhs/image/upload/v1756567670/coverBg_de07rp.avif",
+};
+
+export const getImageUrl = (id: string): string => {
+    return cloudinaryUrls[id] ?? `./assets/images/${id}`;
+};
+
+export default getImageUrl;


### PR DESCRIPTION
## Summary
- replace local ruslit cover image with `getImageUrl`
- add cloudinary util with fallback to local assets

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any in components stories)*

------
https://chatgpt.com/codex/tasks/task_e_68b326d448408324aecd5cad5b244c98